### PR TITLE
Fix for audio listener being on the signalscope

### DIFF
--- a/NomaiVR/NomaiVR.csproj
+++ b/NomaiVR/NomaiVR.csproj
@@ -99,6 +99,9 @@
     <Reference Include="UnityEngine.UI">
       <HintPath>$(GameDir)\OuterWilds_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.AudioModule">
+      <HintPath>$(GameDir)\OuterWilds_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(GameDir)\OuterWilds_Data\Managed\UnityEngine.UIModule.dll</HintPath>

--- a/NomaiVR/Tools/HoldSignalscope.cs
+++ b/NomaiVR/Tools/HoldSignalscope.cs
@@ -16,6 +16,8 @@ namespace NomaiVR
             private static Camera _lensCamera;
             private static Transform _lens;
 
+            private OWCamera _owLensCamera;
+
             internal void Start()
             {
                 if (LoadManager.GetCurrentScene() == OWScene.SolarSystem)
@@ -81,10 +83,11 @@ namespace NomaiVR
 
             private void OnUnequip()
             {
+                _owLensCamera.SetEnabled(false);
                 _lens.gameObject.SetActive(false);
             }
 
-            private static void SetupScopeLens()
+            private void SetupScopeLens()
             {
                 _lens = Instantiate(AssetLoader.ScopeLensPrefab).transform;
                 _lens.parent = _signalscope.transform;
@@ -104,12 +107,12 @@ namespace NomaiVR
                 followTarget.rotationSmoothTime = 0.1f;
                 followTarget.positionSmoothTime = 0.1f;
 
-                var owCamera = _lensCamera.gameObject.AddComponent<OWCamera>();
-                owCamera.useFarCamera = true;
-                owCamera.renderSkybox = true;
-                owCamera.useViewmodels = true;
-                owCamera.farCameraDistance = 50000;
-                owCamera.viewmodelFOV = 70;
+                _owLensCamera = _lensCamera.gameObject.AddComponent<OWCamera>();
+                _owLensCamera.useFarCamera = true;
+                _owLensCamera.renderSkybox = true;
+                _owLensCamera.useViewmodels = true;
+                _owLensCamera.farCameraDistance = 50000;
+                _owLensCamera.viewmodelFOV = 70;
                 var fogEffect = _lensCamera.gameObject.AddComponent<PlanetaryFogImageEffect>();
                 fogEffect.fogShader = Locator.GetPlayerCamera().GetComponent<PlanetaryFogImageEffect>().fogShader;
                 _lensCamera.farClipPlane = 2000f;
@@ -117,11 +120,11 @@ namespace NomaiVR
                 _lensCamera.depth = 0f;
                 _lensCamera.clearFlags = CameraClearFlags.Color;
                 _lensCamera.backgroundColor = Color.black;
-                _lensCamera.enabled = false;
                 _lensCamera.gameObject.SetActive(true);
 
                 // The camera on this prefab would istantiate an AudioListener enabled by default
                 // which would break 3DAudio and tie it to the hands.
+                _owLensCamera.SetEnabled(false);
                 _lensCamera.gameObject.GetComponent<AudioListener>().enabled = false;
             }
 
@@ -153,7 +156,7 @@ namespace NomaiVR
                 if (OWInput.IsNewlyPressed(InputLibrary.scopeView, InputMode.All) && ToolHelper.Swapper.IsInToolMode(ToolMode.SignalScope, ToolGroup.Suit))
                 {
                     _lens.gameObject.SetActive(!_lens.gameObject.activeSelf);
-                    _lensCamera.enabled = _lens.gameObject.activeSelf;
+                    _owLensCamera.SetEnabled(_lens.gameObject.activeSelf);
                 }
             }
 

--- a/NomaiVR/Tools/HoldSignalscope.cs
+++ b/NomaiVR/Tools/HoldSignalscope.cs
@@ -118,6 +118,10 @@ namespace NomaiVR
                 _lensCamera.clearFlags = CameraClearFlags.Color;
                 _lensCamera.backgroundColor = Color.black;
                 _lensCamera.gameObject.SetActive(true);
+
+                // The camera on this prefab would istantiate an AudioListener enabled by default
+                // which would break 3DAudio and tie it to the hands.
+                _lensCamera.gameObject.GetComponent<AudioListener>().enabled = false;
             }
 
             internal void Update()

--- a/NomaiVR/Tools/HoldSignalscope.cs
+++ b/NomaiVR/Tools/HoldSignalscope.cs
@@ -117,6 +117,7 @@ namespace NomaiVR
                 _lensCamera.depth = 0f;
                 _lensCamera.clearFlags = CameraClearFlags.Color;
                 _lensCamera.backgroundColor = Color.black;
+                _lensCamera.enabled = false;
                 _lensCamera.gameObject.SetActive(true);
 
                 // The camera on this prefab would istantiate an AudioListener enabled by default
@@ -152,6 +153,7 @@ namespace NomaiVR
                 if (OWInput.IsNewlyPressed(InputLibrary.scopeView, InputMode.All) && ToolHelper.Swapper.IsInToolMode(ToolMode.SignalScope, ToolGroup.Suit))
                 {
                     _lens.gameObject.SetActive(!_lens.gameObject.activeSelf);
+                    _lensCamera.enabled = _lens.gameObject.activeSelf;
                 }
             }
 


### PR DESCRIPTION
A quick pull request to fix a small bug I found. The ScopeLens prefab has a Camera without an AudioListener so it instantiates one as soon as it is in the scene. Due to hierarchy shenanigans it could get priority over the PlayerCamera one.

This would cause the audio being directional with respect to the hand instead of the head.