### PR TITLE
Prevent destroyed canvases from being tracked by menu fixes

### DIFF
--- a/NomaiVR/ReusableBehaviours/DestroyObserver.cs
+++ b/NomaiVR/ReusableBehaviours/DestroyObserver.cs
@@ -4,15 +4,15 @@ using System.Linq;
 using System.Text;
 using UnityEngine;
 
-namespace NomaiVR.ReusableBehaviours
+namespace NomaiVR
 {
     public class DestroyObserver : MonoBehaviour
     {
-        public event Action OnObjectDestroyed;
+        public event Action OnDestroyed;
 
         private void OnDestroy()
         {
-            OnObjectDestroyed?.Invoke();
+            OnDestroyed?.Invoke();
         }
     }
 }

--- a/NomaiVR/ReusableBehaviours/DestroyObserver.cs
+++ b/NomaiVR/ReusableBehaviours/DestroyObserver.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace NomaiVR.ReusableBehaviours
+{
+    public class DestroyObserver : MonoBehaviour
+    {
+        public event Action OnObjectDestroyed;
+
+        private void OnDestroy()
+        {
+            OnObjectDestroyed?.Invoke();
+        }
+    }
+}

--- a/NomaiVR/UI/Menus.cs
+++ b/NomaiVR/UI/Menus.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using NomaiVR.ReusableBehaviours;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
@@ -184,6 +185,11 @@ namespace NomaiVR
                     followTarget.positionSmoothTime = 0.5f;
                     followTarget.rotationSmoothTime = 0.5f;
                 }
+
+                canvas.gameObject.AddComponent<DestroyObserver>().OnObjectDestroyed += () =>
+                {
+                    _canvasObjectsToHide.Remove(canvas.gameObject);
+                };
             }
 
             private static void AdjustScaler(Canvas canvas)

--- a/NomaiVR/UI/Menus.cs
+++ b/NomaiVR/UI/Menus.cs
@@ -1,5 +1,4 @@
-﻿using NomaiVR.ReusableBehaviours;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
@@ -186,7 +185,7 @@ namespace NomaiVR
                     followTarget.rotationSmoothTime = 0.5f;
                 }
 
-                canvas.gameObject.AddComponent<DestroyObserver>().OnObjectDestroyed += () =>
+                canvas.gameObject.AddComponent<DestroyObserver>().OnDestroyed += () =>
                 {
                     _canvasObjectsToHide.Remove(canvas.gameObject);
                 };


### PR DESCRIPTION
This was causing a lot of NullReferenceExceptions during the credits screen. Presumably due to the logging overhead it was also causing preformance issues.