### PR TITLE
Added Snap Turning

### DIFF
--- a/NomaiVR/ModConfig/IModSettingProvider.cs
+++ b/NomaiVR/ModConfig/IModSettingProvider.cs
@@ -18,7 +18,7 @@ namespace NomaiVR.ModConfig
         bool FlashlightGesture { get; }
         bool ControllerOrientedMovement { get; }
         bool SnapTurning { get; }
-        float SnapTurnIncrement { get; }
+        string SnapTurnIncrement { get; }
         bool AutoHideToolbelt { get; }
         float ToolbeltHeight { get; }
         float HudScale { get; }

--- a/NomaiVR/ModConfig/IModSettingProvider.cs
+++ b/NomaiVR/ModConfig/IModSettingProvider.cs
@@ -17,6 +17,8 @@ namespace NomaiVR.ModConfig
         bool PreventClipping { get; }
         bool FlashlightGesture { get; }
         bool ControllerOrientedMovement { get; }
+        bool SnapTurning { get; }
+        float SnapTurnIncrement { get; }
         bool AutoHideToolbelt { get; }
         float ToolbeltHeight { get; }
         float HudScale { get; }

--- a/NomaiVR/ModConfig/ModSettings.cs
+++ b/NomaiVR/ModConfig/ModSettings.cs
@@ -19,6 +19,8 @@ namespace NomaiVR.ModConfig
         public static bool PreventClipping => settingsProvider.PreventClipping;
         public static bool FlashlightGesture => settingsProvider.FlashlightGesture;
         public static bool ControllerOrientedMovement => settingsProvider.ControllerOrientedMovement;
+        public static bool SnapTurning => settingsProvider.SnapTurning;
+        public static float SnapTurnIncrement => settingsProvider.SnapTurnIncrement;
         public static bool AutoHideToolbelt => settingsProvider.AutoHideToolbelt;
         public static float ToolbeltHeight => settingsProvider.ToolbeltHeight;
         public static float HudScale => settingsProvider.HudScale;

--- a/NomaiVR/ModConfig/ModSettings.cs
+++ b/NomaiVR/ModConfig/ModSettings.cs
@@ -20,7 +20,7 @@ namespace NomaiVR.ModConfig
         public static bool FlashlightGesture => settingsProvider.FlashlightGesture;
         public static bool ControllerOrientedMovement => settingsProvider.ControllerOrientedMovement;
         public static bool SnapTurning => settingsProvider.SnapTurning;
-        public static float SnapTurnIncrement => settingsProvider.SnapTurnIncrement;
+        public static string SnapTurnIncrement => settingsProvider.SnapTurnIncrement;
         public static bool AutoHideToolbelt => settingsProvider.AutoHideToolbelt;
         public static float ToolbeltHeight => settingsProvider.ToolbeltHeight;
         public static float HudScale => settingsProvider.HudScale;

--- a/NomaiVR/ModConfig/OWMLSettingsProvider.cs
+++ b/NomaiVR/ModConfig/OWMLSettingsProvider.cs
@@ -19,7 +19,7 @@ namespace NomaiVR.ModConfig
         public bool FlashlightGesture { get; private set; }
         public bool ControllerOrientedMovement { get; private set; }
         public bool SnapTurning { get; private set; }
-        public float SnapTurnIncrement { get; private set; }
+        public string SnapTurnIncrement { get; private set; }
         public bool AutoHideToolbelt { get; private set; }
         public float ToolbeltHeight { get; private set; }
         public float HudScale { get; private set; }
@@ -41,7 +41,7 @@ namespace NomaiVR.ModConfig
             ShowHelmet = config.GetSettingsValue<bool>("helmetVisibility");
             ControllerOrientedMovement = config.GetSettingsValue<bool>("movementControllerOriented");
             SnapTurning = config.GetSettingsValue<bool>("snapTurning");
-            SnapTurnIncrement = config.GetSettingsValue<float>("snapTurnIncrement");
+            SnapTurnIncrement = config.GetSettingsValue<string>("snapTurnIncrement");
             EnableGesturePrompts = config.GetSettingsValue<bool>("showGesturePrompts");
             EnableHandLaser = config.GetSettingsValue<bool>("showHandLaser");
             EnableFeetMarker = config.GetSettingsValue<bool>("showFeetMarker");

--- a/NomaiVR/ModConfig/OWMLSettingsProvider.cs
+++ b/NomaiVR/ModConfig/OWMLSettingsProvider.cs
@@ -18,6 +18,8 @@ namespace NomaiVR.ModConfig
         public bool PreventClipping { get; private set; }
         public bool FlashlightGesture { get; private set; }
         public bool ControllerOrientedMovement { get; private set; }
+        public bool SnapTurning { get; private set; }
+        public float SnapTurnIncrement { get; private set; }
         public bool AutoHideToolbelt { get; private set; }
         public float ToolbeltHeight { get; private set; }
         public float HudScale { get; private set; }
@@ -38,6 +40,8 @@ namespace NomaiVR.ModConfig
             VibrationStrength = config.GetSettingsValue<float>("vibrationIntensity");
             ShowHelmet = config.GetSettingsValue<bool>("helmetVisibility");
             ControllerOrientedMovement = config.GetSettingsValue<bool>("movementControllerOriented");
+            SnapTurning = config.GetSettingsValue<bool>("snapTurning");
+            SnapTurnIncrement = config.GetSettingsValue<float>("snapTurnIncrement");
             EnableGesturePrompts = config.GetSettingsValue<bool>("showGesturePrompts");
             EnableHandLaser = config.GetSettingsValue<bool>("showHandLaser");
             EnableFeetMarker = config.GetSettingsValue<bool>("showFeetMarker");

--- a/NomaiVR/ModConfig/default-config.json
+++ b/NomaiVR/ModConfig/default-config.json
@@ -78,6 +78,20 @@
       "yes": "Controller",
       "no": "Head"
     },
+    "snapTurning": {
+      "type": "toggle",
+      "value": false,
+      "title": "Snap turning",
+      "yes": "Enabled",
+      "no": "Disabled"
+    },
+    "snapTurnIncrement": {
+      "type": "slider",
+      "value": 45,
+      "min": 15,
+      "max": 90,
+      "title": "Snap turn increment"
+    },
     "showGesturePrompts": {
       "type": "toggle",
       "value": true,

--- a/NomaiVR/ModConfig/default-config.json
+++ b/NomaiVR/ModConfig/default-config.json
@@ -86,10 +86,15 @@
       "no": "Disabled"
     },
     "snapTurnIncrement": {
-      "type": "slider",
-      "value": 45,
-      "min": 15,
-      "max": 90,
+      "type": "selector",
+      "value": "45",
+      "options": [
+        "15",
+        "30",
+        "45",
+        "60",
+        "90"
+      ],
       "title": "Snap turn increment"
     },
     "showGesturePrompts": {

--- a/NomaiVR/Player/PlayerBodyPosition.cs
+++ b/NomaiVR/Player/PlayerBodyPosition.cs
@@ -159,7 +159,7 @@ namespace NomaiVR.Player
                         {
                             isSnapTurnInCooldown = true;
                             float sign = Mathf.Sign(turnInput);
-                            Quaternion snapRotation = Quaternion.AngleAxis(ModSettings.SnapTurnIncrement * sign, playerBody.transform.up);
+                            Quaternion snapRotation = Quaternion.AngleAxis(GetSnapTurnIncrement() * sign, playerBody.transform.up);
                             var fromToSnap = Quaternion.FromToRotation(playerBody.transform.forward, snapRotation * playerBody.transform.forward);
 
                             rotationSetter(fromToSnap * playerBody.transform.rotation);
@@ -224,6 +224,25 @@ namespace NomaiVR.Player
                     //Returns FOV scaled by scale factor
                     if (__instance.mainCamera.stereoEnabled) __result = CameraHelper.GetScaledFieldOfView(__instance.mainCamera);
                     return !__instance.mainCamera.stereoEnabled;
+                }
+
+                private static float GetSnapTurnIncrement()
+                {
+                    switch(ModSettings.SnapTurnIncrement)
+                    {
+                        case "15":
+                            return 15f;
+                        case "30":
+                            return 30f;
+                        case "45":
+                            return 45f;
+                        case "60":
+                            return 60f;
+                        case "90":
+                            return 90f;
+                        default:
+                            return 45f;
+                    }
                 }
             }
 

--- a/NomaiVR/Player/PlayerBodyPosition.cs
+++ b/NomaiVR/Player/PlayerBodyPosition.cs
@@ -14,6 +14,8 @@ namespace NomaiVR.Player
 
         public class Behaviour : MonoBehaviour
         {
+            public static Action OnSnapTurn;
+
             private Transform cameraParent;
             private static Transform playArea;
             private static OWCamera playerCamera;
@@ -154,6 +156,7 @@ namespace NomaiVR.Player
                     if (ModSettings.SnapTurning)
                     {
                         float turnInput = turnAction.axis.x;
+
                         // If snap turning, only do the snap turn, skip reorienting the play area
                         if (!isSnapTurnInCooldown && Mathf.Abs(turnInput) > snapTurnInputThreshold)
                         {
@@ -163,6 +166,7 @@ namespace NomaiVR.Player
                             var fromToSnap = Quaternion.FromToRotation(playerBody.transform.forward, snapRotation * playerBody.transform.forward);
 
                             rotationSetter(fromToSnap * playerBody.transform.rotation);
+                            OnSnapTurn?.Invoke();
                             return;
                         }
                     }

--- a/NomaiVR/Player/PlayerBodyPosition.cs
+++ b/NomaiVR/Player/PlayerBodyPosition.cs
@@ -153,7 +153,7 @@ namespace NomaiVR.Player
                         return;
                     }
 
-                    if (ModSettings.SnapTurning)
+                    if (ModSettings.SnapTurning && !PlayerState.InZeroG())
                     {
                         float turnInput = turnAction.axis.x;
 


### PR DESCRIPTION
- Disabled by default, can be enabled in settings (currently below controller-oriented movement setting)
- Rotation amount per input can also be defined in settings (current range is 15 - 90 degrees)
- Default input action is the right thumb stick (same as smooth turn)
- Snap turning only applies to character movement, doesn't change thruster/ship movement

Closes #494